### PR TITLE
fix(types): add BannerImage to forum_update_params

### DIFF
--- a/src/whop_sdk/types/forum_update_params.py
+++ b/src/whop_sdk/types/forum_update_params.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from typing import Optional
-from typing_extensions import TypedDict
+from typing_extensions import Required, TypedDict
 
 from .._types import SequenceNotStr
 from .shared.who_can_post_types import WhoCanPostTypes
 from .shared.who_can_comment_types import WhoCanCommentTypes
 from .shared.email_notification_preferences import EmailNotificationPreferences
 
-__all__ = ["ForumUpdateParams"]
+__all__ = ["ForumUpdateParams", "BannerImage"]
 
 
 class ForumUpdateParams(TypedDict, total=False):
@@ -18,6 +18,12 @@ class ForumUpdateParams(TypedDict, total=False):
     """A list of words that are automatically blocked from posts in this forum.
 
     For example, ['spam', 'scam'].
+    """
+
+    banner_image: Optional[BannerImage]
+    """The banner image displayed at the top of the forum page.
+
+    Pass null to remove the existing banner.
     """
 
     email_notification_preference: Optional[EmailNotificationPreferences]
@@ -28,3 +34,13 @@ class ForumUpdateParams(TypedDict, total=False):
 
     who_can_post: Optional[WhoCanPostTypes]
     """Who can post on a forum feed"""
+
+
+class BannerImage(TypedDict, total=False):
+    """The banner image displayed at the top of the forum page.
+
+    Pass null to remove the existing banner.
+    """
+
+    id: Required[str]
+    """The ID of an existing file object."""


### PR DESCRIPTION
Release PR #44 was failing pyright lint: `"BannerImage" is not a known attribute of module ".forum_update_params"`.

`resources/forums.py` references `forum_update_params.BannerImage` but `types/forum_update_params.py` was missing both the `BannerImage` class and the `banner_image` field — a codegen-side artifact of the merge conflict resolution where `forums.py` was taken from the generated branch but the type file had a different cross-branch split (generated had `BannerImage` but was missing `banned_words`; integrated had `banned_words` but was missing `BannerImage`; no conflict raised, integrated side was used).

Unified `forum_update_params.py` to match the live public OpenAPI spec — both `banned_words` AND `banner_image`/`BannerImage` are present, matching `api.whop.com/openapi.json` PATCH /forums/{id}. `ruff check` + `pyright` pass clean locally.