### PR TITLE
fix(tests): pass required company_id to invoices.list() calls

### DIFF
--- a/tests/api_resources/test_invoices.py
+++ b/tests/api_resources/test_invoices.py
@@ -408,7 +408,9 @@ class TestInvoices:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     def test_method_list(self, client: Whop) -> None:
-        invoice = client.invoices.list()
+        invoice = client.invoices.list(
+            company_id="biz_xxxxxxxxxxxxxx",
+        )
         assert_matches_type(SyncCursorPage[InvoiceListItem], invoice, path=["response"])
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -433,7 +435,9 @@ class TestInvoices:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     def test_raw_response_list(self, client: Whop) -> None:
-        response = client.invoices.with_raw_response.list()
+        response = client.invoices.with_raw_response.list(
+            company_id="biz_xxxxxxxxxxxxxx",
+        )
 
         assert response.is_closed is True
         assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -443,7 +447,9 @@ class TestInvoices:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     def test_streaming_response_list(self, client: Whop) -> None:
-        with client.invoices.with_streaming_response.list() as response:
+        with client.invoices.with_streaming_response.list(
+            company_id="biz_xxxxxxxxxxxxxx",
+        ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
 
@@ -1009,7 +1015,9 @@ class TestAsyncInvoices:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     async def test_method_list(self, async_client: AsyncWhop) -> None:
-        invoice = await async_client.invoices.list()
+        invoice = await async_client.invoices.list(
+            company_id="biz_xxxxxxxxxxxxxx",
+        )
         assert_matches_type(AsyncCursorPage[InvoiceListItem], invoice, path=["response"])
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -1034,7 +1042,9 @@ class TestAsyncInvoices:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     async def test_raw_response_list(self, async_client: AsyncWhop) -> None:
-        response = await async_client.invoices.with_raw_response.list()
+        response = await async_client.invoices.with_raw_response.list(
+            company_id="biz_xxxxxxxxxxxxxx",
+        )
 
         assert response.is_closed is True
         assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -1044,7 +1054,9 @@ class TestAsyncInvoices:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     async def test_streaming_response_list(self, async_client: AsyncWhop) -> None:
-        async with async_client.invoices.with_streaming_response.list() as response:
+        async with async_client.invoices.with_streaming_response.list(
+            company_id="biz_xxxxxxxxxxxxxx",
+        ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
 


### PR DESCRIPTION
Release PR #44 was failing pyright lint after the merge conflict resolution in PR #884:

> \`Argument missing for parameter \"company_id\"\`

\`invoices.list()\` in the resource now requires \`company_id: str\` (no \`Omit\`), but the bare \`test_method_list\` / \`test_raw_response_list\` / \`test_streaming_response_list\` variants (sync + async) were calling \`list()\` with no args. This was a cross-file consistency artifact of the merge conflict resolution — the test file was taken from the codegen side (where \`company_id\` was \`Optional\`) but the resource file had \`company_id\` as required from a different codegen run.

Added \`company_id=\"biz_xxxxxxxxxxxxxx\"\` (same pattern used by \`test_method_list_with_all_params\`) to the six affected list-variant calls. Local \`ruff check\` + \`pyright\` clean.